### PR TITLE
corrected hardcoded nginx version 1.10.1. check

### DIFF
--- a/test/integration/serverspec/spec/nginx/nginx_spec.rb
+++ b/test/integration/serverspec/spec/nginx/nginx_spec.rb
@@ -12,7 +12,7 @@ describe 'Nginx Installation' do
 
   # Correct version of nginx
   describe command('/usr/sbin/nginx -v') do
-    its(:stderr) { should match(%r{nginx version: nginx/1.10.1}) }
+    its(:stderr) { should match(%r{nginx version: nginx/1\.10\.[0-9]+}) }
     its(:exit_status) { should eq 0 }
   end
 


### PR DESCRIPTION
Updated serverspec to consider nginx version 1.10.* as valid - current workshop/lab does not pass acceptance tests as the new nginx version does not match serverspec.