### PR TITLE
support deployment with forked git repo url

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -36,7 +36,7 @@ You can include a parameter to specify your VPN CIDR block for a more secure NAC
 Limits inbound/outbound traffic to the VPC, Github and your CIDR block.
 ```bash
 $ bundle install
-$ rake jenkins:create['192.0.0.0/24']
+$ rake jenkins:create['192.0.0.0/24','git-repo-url']
 ```
 
 ## Updating CloudFormation Templates

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,7 +33,8 @@ $ rake jenkins:create
 
 You can include a parameter to specify your VPN CIDR block for a more secure NACL/Security Group configuration:
 
-Limits inbound/outbound traffic to the VPC, Github and your CIDR block.
+Limits inbound/outbound traffic to the VPC, Github and your CIDR block. You can use your own github repo foked from this one. 
+You can change the source reop from `pipeline/jobs/jobdsl.groovy` file to create new set of rules
 ```bash
 $ bundle install
 $ rake jenkins:create['192.0.0.0/24','git-repo-url']

--- a/pipeline/tasks/jenkins.rake
+++ b/pipeline/tasks/jenkins.rake
@@ -10,11 +10,13 @@ region = 'us-east-1' if ENV['AWS_REGION'].nil?
 namespace :jenkins do
   desc 'Create a Workshop VPC + Jenkins'
   # task :create, [:vpc_id, :subnet_id, :world_cidr] do |_, opts|
-  task :create, [:world_cidr] do |_, opts|
+  task :create, [:world_cidr, :gitrepo_url] do |_, opts|
     opts[:world_cidr] = '0.0.0.0/0'
 
     world_cidr = opts[:world_cidr]
+    gitrepo_url = opts[:gitrepo_url]
     world_cidr = '0.0.0.0/0' if world_cidr.nil?
+    gitrepo_url = 'git@github.com:stelligent/aws-devsecops-workshop.git' if gitrepo_url.nil?
 
     # Compile the template
     cfn_template_path = 'provisioning/cloudformation/templates/workshop-jenkins'
@@ -32,6 +34,10 @@ namespace :jenkins do
           {
             parameter_key: 'WorldCIDR',
             parameter_value: world_cidr
+          },
+          {
+            parameter_key: 'GitRepoUrl',
+            parameter_value: gitrepo_url
           }
         ]
       )

--- a/provisioning/cloudformation/templates/workshop-jenkins.json
+++ b/provisioning/cloudformation/templates/workshop-jenkins.json
@@ -335,6 +335,7 @@
                 {
                   "Ref": "ConfigRulesUser"
                 },
+                "\"\n",
                 "export git_repo_url=\"",
                 {
                   "Ref": "GitRepoUrl"

--- a/provisioning/cloudformation/templates/workshop-jenkins.json
+++ b/provisioning/cloudformation/templates/workshop-jenkins.json
@@ -16,6 +16,11 @@
       "Type": "String",
       "Description": "The CIDR block to allow HTTP access to Jenkins with.",
       "Default": "192.30.252.0/22"
+    },
+    "GitRepoUrl": {
+      "Type": "String",
+      "Description": "Your Customized Github Repo aws-devsecops-workshop. Default: git@github.com:stelligent/aws-devsecops-workshop.git",
+      "Default": "git@github.com:stelligent/aws-devsecops-workshop.git"
     }
   },
   "Resources": {
@@ -155,14 +160,6 @@
             "ToPort": "443",
             "CidrIp": {
               "Ref": "WorldCIDR"
-            }
-          },
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "443",
-            "ToPort": "443",
-            "CidrIp": {
-              "Ref": "GithubCIDR"
             }
           },
           {
@@ -338,7 +335,16 @@
                 {
                   "Ref": "ConfigRulesUser"
                 },
+                "export git_repo_url=\"",
+                {
+                  "Ref": "GitRepoUrl"
+                },
                 "\"\n",
+                "# Install SSM\n",
+                "mkdir -p /tmp/ssm; cd /tmp/;\n",
+                "wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb\n",
+                "sudo dpkg -i amazon-ssm-agent.deb\n",
+                "sudo start amazon-ssm-agent\n",
                 "#!/bin/bash --login\n",
                 "set -ex\n",
                 "\n",
@@ -425,6 +431,7 @@
                 "sed -i.bak \"s#STACK_NAME_TOKEN#${stack_name}#g\" /var/lib/jenkins/config.xml\n",
                 "sed -i.bak \"s#REGION_TOKEN#${region}#g\" /var/lib/jenkins/config.xml\n",
                 "sed -i.bak \"s#0.0.0.0/0#${world_cidr}#g\" /var/lib/jenkins/config.xml\n",
+                "sed -i.bak \"s#git@github.com:stelligent/aws-devsecops-workshop.git#${git_repo_url}#g\" /var/lib/jenkins/jobs/seed-aws-devsecops-workshop/config.xml\n",
                 "\n",
                 "# Restart Jenkins\n",
                 "service jenkins restart\n",
@@ -467,6 +474,7 @@
           ]
         },
         "Path": "/",
+        "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"],
         "Policies": [
           {
             "PolicyName": "aws-devsecops-jenkins-role",
@@ -475,6 +483,11 @@
                 {
                   "Effect": "Allow",
                   "Action": "cloudformation:*",
+                  "Resource": "*"
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": "ssm:*",
                   "Resource": "*"
                 },
                 {


### PR DESCRIPTION
The current deployment is good that it creates a set of default rules, but to allow customers and workshop attendees to extend these rules for their needs, we can allow them to use their repo as the source repo. 

This pull request is allowing attendees to create the stack with a git repo parameter. For example using command `rake jenkins:create['0.0.0.0/0','git@github.com:allinwonder/aws-devsecops-workshop.git']` will create a stack looking into the source repo from  "https://github.com/allinwonder/aws-devsecops-workshop/" 