### PR TITLE
fixed stylization errors cause failure in jenkins build

### DIFF
--- a/pipeline/lib/pipeline/cfn_helper.rb
+++ b/pipeline/lib/pipeline/cfn_helper.rb
@@ -61,7 +61,7 @@ module Pipeline
                        .key_pairs.empty?
       aws_check && File.exist?(key_path)
     rescue Aws::EC2::Errors::InvalidKeyPairNotFound
-      return false
+      false
     end
 
     def delete_old_keypair(key_path)
@@ -75,9 +75,9 @@ module Pipeline
 
     def stack_exists
       @cloudformation.describe_stacks(stack_name: stack_name)
-      return true
+      true
     rescue Aws::CloudFormation::Errors::ValidationError
-      return false
+      false
     end
 
     def connector_sg


### PR DESCRIPTION
I am working on a jenkins build to get the build pipeline to work. The errors Jenkins is throwing is regarding the return statement. I ran rubocop -a . to fix the issue to test and see if it will work in the pipeline.