### PR TITLE
add lockable-resources plugin

### DIFF
--- a/provisioning/jenkins/playbook.yml
+++ b/provisioning/jenkins/playbook.yml
@@ -67,6 +67,7 @@
       - docker-commons
       - authentication-tokens
       - script-security
+      - lockable-resources
 
   tasks:
     - name: set jenkins admin password fact


### PR DESCRIPTION
dependencies install is broken by ansible plugin installer, and must be declared explicitly